### PR TITLE
implement record keyword

### DIFF
--- a/src/projected_to.jl
+++ b/src/projected_to.jl
@@ -176,11 +176,20 @@ end
 using Manopt, StaticTools
 
 """
-    project_to(prj::ProjectedTo, f::F, supplementary...)
+    project_to(prj::ProjectedTo, f::F, supplementary..., initialpoint, kwargs...)
 
-Project the function `f` to the exponential family distribution specified by `prj`.
-Additionally `supplementary` distributions can be provided to project a product of `f` and `supplementary` distributions.
-Note that `supplementary` distributions must be of the same type and conditioner as the target distribution.
+Project function `f` onto the exponential family distribution specified by `prj`.
+
+# Arguments
+- `prj::ProjectedTo`: Target exponential family distribution.
+- `f::F`: Function to be projected.
+- `supplementary...`: Additional distributions to project the product of `f` and these distributions (optional).
+- `initialpoint`: Starting point for optimization (optional).
+- `kwargs...`: Additional arguments passed to `Manopt.gradient_descent!` (optional).
+
+# Notes
+- `supplementary` distributions must match the type and conditioner of the target distribution.
+- See [Manopt.jl documentation](https://manoptjl.org/stable/solvers/gradient_descent/#Manopt.gradient_descent) for details on `gradient_descent!` parameters.
 
 ```jldoctest
 julia> using ExponentialFamily, BayesBase
@@ -198,9 +207,8 @@ function project_to(
     prj::ProjectedTo,
     f::F,
     supplementary...;
-    debug = missing,
     initialpoint = nothing,
-    record = missing
+    kwargs...
 ) where {F}
     M = get_projected_to_manifold(prj)
     parameters = get_projected_to_parameters(prj)
@@ -245,8 +253,7 @@ function project_to(
             stopping_criterion = get_stopping_criterion(parameters),
             stepsize = getstepsize(parameters),
             direction = BoundedNormUpdateRule(static(1)),
-            debug = debug,
-            record = record
+            kwargs...
         )
 
         return convert(

--- a/src/projected_to.jl
+++ b/src/projected_to.jl
@@ -200,6 +200,7 @@ function project_to(
     supplementary...;
     debug = missing,
     initialpoint = nothing,
+    record = missing
 ) where {F}
     M = get_projected_to_manifold(prj)
     parameters = get_projected_to_parameters(prj)
@@ -244,6 +245,7 @@ function project_to(
             stopping_criterion = get_stopping_criterion(parameters),
             stepsize = getstepsize(parameters),
             debug = debug,
+            record = record
         )
 
         return convert(

--- a/test/projection/projected_to_tests.jl
+++ b/test/projection/projected_to_tests.jl
@@ -310,7 +310,7 @@ end
             targetfn_1 = (x) -> logpdf(left, x)
             approximated_1 = project_to(prj, targetfn_1, right, record = record)
             recorded_values = record[1].recorded_values
-            @test all(<=(0), diff(recorded_values))
+            @test recorded_values[1] > recorded_values[end]
         end
 
         @testset "case 2 without supplementary" begin
@@ -318,7 +318,7 @@ end
             targetfn_2 = (x) -> logpdf(ProductOf(left, right), x)
             approximated_2 = project_to(prj, targetfn_2; record = record)
             recorded_values = record[1].recorded_values
-            @test all(<=(0), diff(recorded_values))
+            @test recorded_values[1] > recorded_values[end]
         end
     end
 end

--- a/test/projection/projected_to_tests.jl
+++ b/test/projection/projected_to_tests.jl
@@ -303,6 +303,11 @@ end
         targetfn_1 = (x) -> logpdf(left, x)
         approximated_1 = project_to(prj, targetfn_1, right, record = record)
         @test all(map((before, after) ->  before > after, record[1:end-1], record[2:end]))
+
+        record = [RecordCost()]
+        targetfn_2 = (x) -> logpdf(ProductOf(left, right), x)
+        approximated_2 = project_to(prj, targetfn_2)
+        @test all(map((before, after) ->  before > after, record[1:end-1], record[2:end]))
     end
 end 
 


### PR DESCRIPTION
This PR adds a record keyword to `project_to` that is passed `gradient_descent!` inside to record cost values.

A new test added that cost is actually decreasing trough iterations.