### PR TITLE
test(fix): convergence tests should always return series

### DIFF
--- a/test/projection/projected_to_setuptests.jl
+++ b/test/projection/projected_to_setuptests.jl
@@ -82,8 +82,6 @@ function test_convergence_nsamples(
     nsamples_rng = StableRNG(42),
     nsamples_stepsize = ConstantStepsize(0.1),
     nsamples_required_accuracy = 1e-1,
-    kwargs...,
-)
     experiment = map(nsamples_range) do nsamples
         parameters = ProjectionParameters(
             strategy = ExponentialFamilyProjection.ControlVariateStrategy(
@@ -99,8 +97,9 @@ function test_convergence_nsamples(
         approximated = project_to(projection, targetfn)
         divergence = test_convergence_metric(approximated, distribution)
         return divergence, approximated
-    end
-
+    end,
+    kwargs...,
+)
     divergence = map(e -> e[1], experiment)
     approximated = map(e -> e[2], experiment)
 
@@ -151,8 +150,6 @@ function test_convergence_niterations(
     niterations_rng = StableRNG(42),
     niterations_stepsize = ConstantStepsize(0.1),
     niterations_required_accuracy = 1e-1,
-    kwargs...,
-)
     experiment = map(niterations_range) do niterations
         parameters = ProjectionParameters(
             strategy = ExponentialFamilyProjection.ControlVariateStrategy(
@@ -168,8 +165,10 @@ function test_convergence_niterations(
         approximated = project_to(projection, targetfn)
         divergence = test_convergence_metric(approximated, distribution)
         return divergence, approximated
-    end
-
+    end,
+    kwargs...,
+)
+    
     divergence = map(e -> e[1], experiment)
     approximated = map(e -> e[2], experiment)
 

--- a/test/projection/projected_to_setuptests.jl
+++ b/test/projection/projected_to_setuptests.jl
@@ -110,7 +110,9 @@ function test_convergence_nsamples(
         @warn "Convergence test for `$(distribution)` failed. The approximated distributions were `$(approximated)`. The divergences was `$(divergence)`."
     end
 
-    return test_required_accuracy && test_convergence_to_stable_point(divergence)
+    test_convergence, series = test_convergence_to_stable_point(divergence)
+
+    return test_required_accuracy && test_convergence, series
 end
 
 _convergence_niterations_default_range(distribution) =
@@ -177,7 +179,9 @@ function test_convergence_niterations(
         @warn "Convergence test for `$(distribution)` failed. The approximated distributions were `$(approximated)`. The divergences was `$(divergence)`."
     end
 
-    return test_required_accuracy && test_convergence_to_stable_point(divergence)
+    test_convergence, series = test_convergence_to_stable_point(divergence)
+
+    return test_required_accuracy && test_convergence, series
 end
 
 # The metric we are using in the tests is `KL` divergence

--- a/test/projection/projected_to_tests.jl
+++ b/test/projection/projected_to_tests.jl
@@ -306,61 +306,18 @@ end
     include("projected_to_setuptests.jl")
 
     rng = StableRNG(42)
+
+    # small variance
     for c in (0, 1, 5, 10), v in (1e-3, 1e-2), n in (20, 100)
         series = map(x -> rand(rng, Normal(1 / x^(0.5) + c, v)), 1:n)
-        converged, _ = test_convergence_to_stable_point(series)
+        converged = test_convergence_to_stable_point(series)
         @test converged
     end
-end
 
-@testitem "test_convergence_nsamples" begin
-    include("projected_to_setuptests.jl")
-    
-    @testset "test_convergence_nsamples tracks divergence" begin
-        distribution = Normal(0, 1)
-        nsamples_range = 
-        diverged_series = map(1:100) do nsamples
-            approximation = Normal(nsamples, nsamples)
-            (kldivergence(approximation, distribution), approximation)
-        end 
-        test_result, series = test_convergence_nsamples(distribution, (x) -> 1, NormalMeanVariance, (), missing, experiment = diverged_series)
-        @test !test_result
+    # large variance
+    for c in (0, 1, 5, 10), v in (1e+3, 1e+2), n in (20, 100)
+        series = map(x -> rand(rng, Normal(1 / x^(0.5) + c, v)), 1:n)
+        converged = test_convergence_to_stable_point(series)
+        @test !converged
     end
-    
-    @testset "test_convergence_nsamples tracks cpnvergence" begin
-        distribution = Normal(0, 1)
-        nsamples_range = 
-        convergent_series = map(1:100) do nsamples
-            approximation = Normal(0, 1 + 1/nsamples)
-            (kldivergence(approximation, distribution), approximation)
-        end 
-        test_result, series = test_convergence_nsamples(distribution, (x) -> 1, NormalMeanVariance, (), missing, experiment = convergent_series)
-        @test test_result
-    end     
-end
-
-@testitem "test_convergence_niterations" begin
-    include("projected_to_setuptests.jl")
-    
-    @testset "test_convergence_niterations tracks divergence" begin
-        distribution = Normal(0, 1)
-        nsamples_range = 
-        diverged_series = map(1:100) do niterations
-            approximation = Normal(niterations, niterations)
-            (kldivergence(approximation, distribution), approximation)
-        end 
-        test_result, series = test_convergence_niterations(distribution, (x) -> 1, NormalMeanVariance, (), missing, experiment = diverged_series)
-        @test !test_result
-    end
-    
-    @testset "test_convergence_niterations tracks convergence" begin
-        distribution = Normal(0, 1)
-        nsamples_range = 
-        convergent_series = map(1:100) do niterations
-            approximation = Normal(0, 1 + 1/niterations)
-            (kldivergence(approximation, distribution), approximation)
-        end 
-        test_result, series = test_convergence_niterations(distribution, (x) -> 1, NormalMeanVariance, (), missing, experiment = convergent_series)
-        @test test_result
-    end    
 end

--- a/test/projection/projected_to_tests.jl
+++ b/test/projection/projected_to_tests.jl
@@ -312,3 +312,55 @@ end
         @test converged
     end
 end
+
+@testitem "test_convergence_nsamples" begin
+    include("projected_to_setuptests.jl")
+    
+    @testset "test_convergence_nsamples tracks divergence" begin
+        distribution = Normal(0, 1)
+        nsamples_range = 
+        diverged_series = map(1:100) do nsamples
+            approximation = Normal(nsamples, nsamples)
+            (kldivergence(approximation, distribution), approximation)
+        end 
+        test_result, series = test_convergence_nsamples(distribution, (x) -> 1, NormalMeanVariance, (), missing, experiment = diverged_series)
+        @test !test_result
+    end
+    
+    @testset "test_convergence_nsamples tracks cpnvergence" begin
+        distribution = Normal(0, 1)
+        nsamples_range = 
+        convergent_series = map(1:100) do nsamples
+            approximation = Normal(0, 1 + 1/nsamples)
+            (kldivergence(approximation, distribution), approximation)
+        end 
+        test_result, series = test_convergence_nsamples(distribution, (x) -> 1, NormalMeanVariance, (), missing, experiment = convergent_series)
+        @test test_result
+    end     
+end
+
+@testitem "test_convergence_niterations" begin
+    include("projected_to_setuptests.jl")
+    
+    @testset "test_convergence_niterations tracks divergence" begin
+        distribution = Normal(0, 1)
+        nsamples_range = 
+        diverged_series = map(1:100) do niterations
+            approximation = Normal(niterations, niterations)
+            (kldivergence(approximation, distribution), approximation)
+        end 
+        test_result, series = test_convergence_niterations(distribution, (x) -> 1, NormalMeanVariance, (), missing, experiment = diverged_series)
+        @test !test_result
+    end
+    
+    @testset "test_convergence_niterations tracks convergence" begin
+        distribution = Normal(0, 1)
+        nsamples_range = 
+        convergent_series = map(1:100) do niterations
+            approximation = Normal(0, 1 + 1/niterations)
+            (kldivergence(approximation, distribution), approximation)
+        end 
+        test_result, series = test_convergence_niterations(distribution, (x) -> 1, NormalMeanVariance, (), missing, experiment = convergent_series)
+        @test test_result
+    end    
+end


### PR DESCRIPTION
This PR fixes https://github.com/ReactiveBayes/ExponentialFamilyProjection.jl/issues/13