### PR TITLE
Do not use debug option by default

### DIFF
--- a/src/projected_to.jl
+++ b/src/projected_to.jl
@@ -245,6 +245,10 @@ function project_to(
     )
     strategy = with_state(getstrategy(parameters), state)
 
+    # We disable the default `debug` statements, which are set in `Manopt` 
+    # in order to improve the performance a little bit
+    kwargs = !haskey(kwargs, :debug) ? (; kwargs..., debug = missing) : kwargs
+
     return with_buffer(parameters) do buffer
 
         g_grad_g! = CVICostGradientObjective(f, supplementary_η, strategy, buffer)


### PR DESCRIPTION
This PR modifies the project_to function to ignore the default debug setting from Manopt. This change is made for two main reasons:
- During inference, the projection is called numerous times, making the excessive warnings unnecessary and not significantly impacting the results.
- Disabling the debug option slightly improves the projection’s performance.