### PR TITLE
Allow to put manopt factories into BoundedNormUpdateRule

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -46,7 +46,7 @@ Static = "0.8, 1"
 StaticArrays = "1.9"
 StaticTools = "0.8"
 StatsFuns = "1.3"
-julia = "1.10"
+julia = "1.11"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/manopt/bounded_norm_update_rule.jl
+++ b/src/manopt/bounded_norm_update_rule.jl
@@ -23,6 +23,19 @@ struct BoundedNormUpdateRule{L,D} <: Manopt.DirectionUpdateRule
     direction::D
 end
 
+function init_direction_rule(d, _)
+    return d
+end
+
+function init_direction_rule(d::BoundedNormUpdateRule, ::Any)
+    return d
+end
+
+function init_direction_rule(bounded_direction::BoundedNormUpdateRule{L,D}, M) where {L, D <: Manopt.ManifoldDefaultsFactory}
+    inner_direction = bounded_direction.direction(M)
+    return BoundedNormUpdateRule(bounded_direction.limit, inner_direction)
+end
+
 function BoundedNormUpdateRule(limit; direction = Manopt.IdentityUpdateRule())
     return BoundedNormUpdateRule(limit, direction)
 end

--- a/src/projected_to.jl
+++ b/src/projected_to.jl
@@ -327,13 +327,15 @@ function _kernel_project_to(
     # `gradient_descent!` is a type-unstable call, so better not to use `q = gradient_descent!`
     # `gradient_descent!` will override `q` instead
     q = current_η
+    direction = getdirection(projection_parameters)
+    inited_direction = init_direction_rule(direction, M)
     gradient_descent!(
         M,
         objective,
         current_η;
         stopping_criterion = get_stopping_criterion(projection_parameters),
         stepsize = getstepsize(projection_parameters),
-        direction = getdirection(projection_parameters),
+        direction = inited_direction,
         kwargs...,
     )
 


### PR DESCRIPTION
This pull request enables the use of not only UpdateRules but also update rule factories as a direction in `BoundedNormUpdateRule`.