### PR TITLE
set global seed for reproducibility

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,6 @@
-using ExponentialFamilyProjection, Test, ReTestItems
+using ExponentialFamilyProjection, Test, ReTestItems, Random
+
+# Set the random seed for reproducibility of kl-divergence tests
+Random.seed!(42)
 
 runtests(ExponentialFamilyProjection; memory_threshold = 1.0)


### PR DESCRIPTION
Similar to https://github.com/ReactiveBayes/ExponentialFamilyManifolds.jl/pull/43 but we have `kldivergence` in way more places, where we don't have access to `StableRNG`. Instead I attempt to set the seed once globally before running the tests, hoping they run in the same order every time.... at the very least its not bad to set the seed before running the tests