### PR TITLE
test: stabilize flaky Poisson(10) niterations convergence test

### DIFF
--- a/test/projection/projected_to_poisson_tests.jl
+++ b/test/projection/projected_to_poisson_tests.jl
@@ -9,10 +9,16 @@
     end
 
     @testset let distribution = Poisson(10)
+        # `Poisson` with a large `λ` has high variance, so the Monte-Carlo
+        # gradient estimates are noisy. With too few samples the `niterations`
+        # convergence series sits right at the `stdthreshold` of the stable-point
+        # check and flips to a failure under small numerical perturbations (e.g.
+        # different dependency/Julia/BLAS versions in downstream CI). Using more
+        # samples lowers the KL noise floor well below the threshold.
         @test test_projection_convergence(
             distribution,
             nsamples_range = 500:200:4000,
-            niterations_nsamples = 700,
+            niterations_nsamples = 4000,
         )
     end
 


### PR DESCRIPTION
## Problem

The `Poisson` projection convergence test fails intermittently in the ExponentialFamily.jl downstream CI job (e.g. [run 28360311006](https://github.com/ReactiveBayes/ExponentialFamily.jl/actions/runs/28360311006)). The failure is in the `Poisson(10)` case of `test/projection/projected_to_poisson_tests.jl`.

## Root cause

`test_projection_convergence` runs a `niterations` convergence sub-test that sweeps `niterations = 100:50:1000` with a **fixed `niterations_nsamples = 700`** Monte-Carlo samples per run, then `test_convergence_to_stable_point` requires the tail's rolling std to fall below `stdthreshold = 5e-2`.

For `λ = 10` the Poisson variance is large, so 700 samples leave a KL noise floor right at the `0.05` threshold. The test is deterministic (everything is `StableRNG(42)`-seeded) so it does not randomly flip — but it sits on the pass/fail boundary, and small numerical drift from a different ExponentialFamily.jl / Julia / BLAS version in the downstream job tips it over. That is what makes it look flaky.

The companion `nsamples` sweep already runs up to **4000 samples and passes**, confirming more samples is the correct lever.

## Fix

Raise `niterations_nsamples` from `700` → `4000` for the `Poisson(10)` testset only (matching the `nsamples_range` ceiling that already passes). No shared helpers, other distributions, or convergence criteria are touched.

## Verification

Reproduced the exact CI failure locally (same `max div = 0.278`) and swept sample counts:

| `niterations_nsamples` | result | tail rolling-std (w5 / w10) |
|---|---|---|
| 700 (old) | ❌ fail | 0.073 / 0.091 |
| 2000 | ✅ | 0.034 / 0.028 |
| **4000 (new)** | ✅ | **0.015 / 0.014** |

All three Poisson test items pass locally (8/8). The `Poisson(10)` item is slower (~12s vs ~4s), an acceptable cost for the ~3×-below-threshold margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)