### PR TITLE
PR draft — ClosedFormStrategy: fail clearly on non-constant base measure (fixes issue-01)

### DIFF
--- a/ext/ClosedFormExpectationsExt/ClosedFormExpectationsExt.jl
+++ b/ext/ClosedFormExpectationsExt/ClosedFormExpectationsExt.jl
@@ -52,9 +52,22 @@ function ExponentialFamilyProjection.compute_gradient!(
 
     # Compute ∇_η E[log p̃ * (T - μ)]
     grad_target = mean(ClosedWilliamsProduct(strategy.backend), target_fn, q_dist)
+    # The analytic base-measure correction is only implemented for a constant base measure
+    # (there E[T] = μ makes the -E_q[log h_q (T - μ)] term vanish). For a non-constant base
+    # measure the term is non-zero and is not implemented, so fail clearly rather than
+    # producing an opaque MethodError or silently dropping the term.
+    base_measure_type = ExponentialFamily.isbasemeasureconstant(q_dist)
+    if base_measure_type === ExponentialFamily.NonConstantBaseMeasure()
+        error(
+            "`ClosedFormStrategy` currently supports only variational families with a constant " *
+            "base measure, but got `$(base_measure_type)` for the variational family. The " *
+            "-E_q[log h_q (T - μ)] base-measure correction is not implemented for non-constant " *
+            "base measures. Use `ControlVariateStrategy` instead.",
+        )
+    end
     grad_eta = logbasemeasure_correction(
         strategy,
-        ExponentialFamily.isbasemeasureconstant(q_dist),
+        base_measure_type,
         q_dist,
         grad_target,
     )


### PR DESCRIPTION
## Problem
`ClosedFormStrategy.compute_gradient!` only defines `logbasemeasure_correction` for `ConstantBaseMeasure`. For variational families with a non-constant base measure (`Poisson`, `Chisq`, `Binomial`, `Rayleigh`, `Weibull`, `NegativeBinomial`) the call throws an opaque `MethodError` deep inside the solver.

## Change
Add an explicit, informative guard in the extension's `compute_gradient!` before the base-measure correction, and document the limitation.

### Patch
File: `ext/ClosedFormExpectationsExt/ClosedFormExpectationsExt.jl` (in `ExponentialFamilyProjection.compute_gradient!`)

```diff
     # Compute ∇_η E[log p̃ * (T - μ)]
     grad_target = mean(ClosedWilliamsProduct(strategy.backend), target_fn, q_dist)
+    base_measure_type = ExponentialFamily.isbasemeasureconstant(q_dist)
+    if base_measure_type === ExponentialFamily.NonConstantBaseMeasure()
+        error(
+            "`ClosedFormStrategy` supports only variational families with a constant base measure, " *
+            "but got `$(base_measure_type)` for the variational family. The analytic " *
+            "-E_q[log h_q (T - μ)] base-measure correction is not implemented. " *
+            "Use `ControlVariateStrategy` instead.",
+        )
+    end
     grad_eta = logbasemeasure_correction(
         strategy,
-        ExponentialFamily.isbasemeasureconstant(q_dist),
+        base_measure_type,
         q_dist,
         grad_target,
     )
```

File: `src/strategies/closed_form.jl` — add to the docstring:

```diff
-This strategy provides a "Zero-Variance" gradient estimator, avoiding the noise associated
-with Monte Carlo sampling (like in `ControlVariateStrategy`).
+This strategy provides a "Zero-Variance" gradient estimator, avoiding the noise associated
+with Monte Carlo sampling (like in `ControlVariateStrategy`).
+
+!!! note
+    Currently only target–variational pairs where the variational distribution has a **constant
+    base measure** are supported (e.g. Normal, LogNormal, Beta, Gamma). For variational families
+    with a non-constant base measure (Poisson, Chisq, Binomial, Rayleigh, Weibull,
+    NegativeBinomial) the strategy errors; use `ControlVariateStrategy` for those.
```

## Verification
- Added regression test: `ClosedFormStrategy` on a non-constant-base-measure target errors with the new message (not a `MethodError`).
- Full suite still green.