### PR TITLE
PR draft — Validate captured value in ClosedForm closure extraction (fixes issue-06)

### DIFF
--- a/ext/ClosedFormExpectationsExt/ClosedFormExpectationsExt.jl
+++ b/ext/ClosedFormExpectationsExt/ClosedFormExpectationsExt.jl
@@ -150,6 +150,14 @@ function ExponentialFamilyProjection.preprocess_strategy_argument(
     end
 
     captured = getfield(argument, first(field_names))
+    if !(captured isa Union{Distribution,ProductOf})
+        error(
+            "`ClosedFormStrategy` expected the first captured variable of the closure to be a " *
+            "`Distribution` or `ProductOf`, but got `$(typeof(captured))`. `ClosedFormStrategy` " *
+            "supports closures that capture a single distribution. Pass the `Distribution`/" *
+            "`ProductOf` directly to `project_to` to avoid ambiguity.",
+        )
+    end
     return (strategy, Logpdf(captured))
 end
 


### PR DESCRIPTION
## Problem
`exmplate` `preprocess_strategy_argument(::ClosedFormStrategy, argument::F)` takes `getfield(argument, first(fieldnames(F)))` with no type check; multi-variable closures silently retrieve the wrong (first) captured value.

## Change
`ext/ClosedFormExpectationsExt/ClosedFormExpectationsExt.jl`:

```diff
-    captured = getfield(argument, first(field_names))
-    return (strategy, Logpdf(captured))
+    captured = getfield(argument, first(field_names))
+    if !(captured isa Union{Distribution,ProductOf})
+        error(
+            "`ClosedFormStrategy` expected the first captured variable of the closure to be a " *
+            "`Distribution` or `ProductOf`, but got `$(typeof(captured))`. `ClosedFormStrategy` " *
+            "supports closures that capture exactly one distribution. " *
+            "Pass the `Distribution`/`ProductOf` directly to avoid ambiguity.",
+        )
+    end
+    return (strategy, Logpdf(captured))
```

Optionally, when more than one field is captured, prefer the field whose value is a `Distribution`/`ProductOf` and error only if none is found.

## Verification
- `let a = 5, d = Normal(0,1); fn=(x)->logpdf(d,x)+a; preprocess_strategy_argument(...)` now errors with a clear message instead of silently projecting the scalar `5`.
- Single-distribution closures still work.
- Full suite green.