### PR TITLE
Fix: conditioner equality

### DIFF
--- a/src/projected_to.jl
+++ b/src/projected_to.jl
@@ -288,7 +288,7 @@ function project_to(
             )
         end
         supplementary_ef = convert(ExponentialFamilyDistribution, s)
-        if getconditioner(supplementary_ef) !== get_projected_to_conditioner(prj)
+        if getconditioner(supplementary_ef) != get_projected_to_conditioner(prj)
             error(
                 lazy"Supplementary distributions must have the same conditioner as the projection target `$(get_projected_to_type(prj))` with `conditioner = $(get_projected_to_conditioner(prj))`, got `$(ExponentialFamily.exponential_family_typetag(s))` with `conditioner = $(getconditioner(supplementary_ef))`",
             )


### PR DESCRIPTION
**[Verified audit fix]** — branch `fix/conditioner-equality`.

Commit: `fix: compare supplementary conditioner by equality, not identity`

## Changes

src/projected_to.jl | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

## Verification

Confirmed against `main` in the ReactiveBayes audit (Julia 1.12.6); sources verified read-only. See the branch diff.
