### PR TITLE
PR draft — ControlVariateStrategy `==` includes `base_logpdf_type` (fixes issue-02)

### DIFF
--- a/src/strategies/control_variate.jl
+++ b/src/strategies/control_variate.jl
@@ -27,7 +27,9 @@ get_nsamples(strategy::ControlVariateStrategy) = strategy.nsamples
 get_buffer(strategy::ControlVariateStrategy) = strategy.buffer
 
 function Base.:(==)(a::ControlVariateStrategy, b::ControlVariateStrategy)::Bool
-    return get_nsamples(a) == get_nsamples(b) && get_buffer(a) == get_buffer(b)
+    return get_nsamples(a) == get_nsamples(b) &&
+           get_buffer(a) == get_buffer(b) &&
+           a.base_logpdf_type == b.base_logpdf_type
 end
 
 preprocess_strategy_argument(


### PR DESCRIPTION
## Problem
`ControlVariateStrategy(==)` compares only `nsamples` and `buffer`, ignoring `base_logpdf_type`.

## Change
`srd/strategies/control_variate.jl` — compare `base_logpdf_type` (or its getter) too.

```diff
 function Base.:(==)(a::ControlVariateStrategy, b::ControlVariateStrategy)::Bool
-    return get_nsamples(a) == get_nsamples(b) && get_buffer(a) == get_buffer(b)
+    return get_nsamples(a) == get_nsamples(b) &&
+           get_buffer(a) == get_buffer(b) &&
+           a.base_logpdf_type == b.base_logpdf_type
 end
```

## Verification
Add a unit test: two strategies equal in `nsamples`/`buffer` but differing in `base_logpdf_type` are `!=`.

Closes #100
